### PR TITLE
Added ability to override input URL (aka, EC2) 

### DIFF
--- a/lib/loggly/config.js
+++ b/lib/loggly/config.js
@@ -28,6 +28,7 @@ var Config = exports.Config = function (defaults) {
   this.subdomain = defaults.subdomain;
   this.json = defaults.json || null;
   this.auth = defaults.auth || null;
+  this.inputUrl = defaults.inputUrl || 'https://logs.loggly.com/inputs/';
 };
  
 Config.prototype = {
@@ -44,6 +45,10 @@ Config.prototype = {
   },
   
   get inputUrl () {
-    return 'https://logs.loggly.com/inputs/';
+    return this._inputUrl;
+  },
+  
+  set inputUrl (value) {
+    this._inputUrl = value;
   }
 };


### PR DESCRIPTION
Allows the library to log using the internal EC2 URL.
