### PR TITLE
[fix] Replace Unicode space (U+00A0) with ASCII space

### DIFF
--- a/lib/loggly/config.js
+++ b/lib/loggly/config.js
@@ -26,7 +26,7 @@ var Config = exports.Config = function (defaults) {
   }
   
   this.subdomain = defaults.subdomain;
-  this.json = defaults.json || null;
+  this.json = defaults.json || null;
   this.auth = defaults.auth || null;
 };
  


### PR DESCRIPTION
The space at char 31 on line 29 in `lib/loggly/config.js` is a Unicode space, not an ASCII space. 

I'm sure that's not a problem for anyone in general, but it broke embedding this file in a context where I could only use ASCII chars.
