### PR TITLE
bump version to 0.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loggly",
   "description": "A client implementation for Loggly cloud Logging-as-a-Service API",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>"


### PR DESCRIPTION
This version of node-loggly is now unusable with Loggly V2 since the api url changed, the fix that allowes custom URLs has been already merged 2 months ago but the package version has not been bumped
