### PR TITLE
Use Buffer.byteLength instead of msg.length

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -100,7 +100,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
       'accept':         '*/*',
       'user-agent':     this.userAgent,
       'content-type':   this.json ? 'application/json' : 'text/plain',
-      'content-length': msg.length
+      'content-length': Buffer.byteLength(msg)
     }
   };
 


### PR DESCRIPTION
When logging utf-8 data the module currently responds with the following error:

``` js
client.log({hellå:wårld});
// --> { [Error: Parse Error] bytesParsed: 166, code: 'HPE_INVALID_CONSTANT' }
```

This PR fixes this by using `Buffer.byteLength(msg)` instead of `msg.length` for content-length.
