### PR TITLE
Allow tags to be send by URL instead of HTTP header

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -38,12 +38,13 @@ var Loggly = exports.Loggly = function (options) {
 
   events.EventEmitter.call(this);
 
-  this.subdomain = options.subdomain;
-  this.token     = options.token;
-  this.host      = options.host || 'logs-01.loggly.com';
-  this.json      = options.json || null;
-  this.auth      = options.auth || null;
-  this.userAgent = 'node-loggly ' + loggly.version
+  this.subdomain    = options.subdomain;
+  this.token        = options.token;
+  this.host         = options.host || 'logs-01.loggly.com';
+  this.json         = options.json || null;
+  this.auth         = options.auth || null;
+  this.userAgent    = 'node-loggly ' + loggly.version;
+  this.useTagHeader = "useTagHeader" in options ? options.useTagHeader : true;
 
   //
   // Set the tags on this instance.
@@ -128,7 +129,13 @@ Loggly.prototype.log = function (msg, tags, callback) {
   // Optionally send `X-LOGGLY-TAG` if we have them
   //
   if (tags) {
-    logOptions.headers['x-loggly-tag'] = tags.join(',');
+    //decide whether to add tags as http headers or add them to the URI.
+    if (this.useTagHeader) {
+      logOptions.headers['x-loggly-tag'] = tags.join(',');
+    }
+    else {
+      logOptions.uri += "/tag/" + tags.join(",") + "/";
+    }
   }
 
   common.loggly(logOptions, callback, function (res, body) {


### PR DESCRIPTION
This is a pull request for a temporary fix for this issue
https://github.com/nodejitsu/node-loggly/issues/35

It allows the selection of sending tags as part of the URI instead of the HTTP header X-LOGGLY-TAG. To use the URI option, do:

``` js
    var loggly = require('loggly');

    var client = loggly.createClient({
      token: "your-really-long-input-token",
      subdomain: "your-subdomain",
      auth: {
        username: "your-username",
        password: "your-password"
      },
      useTagHeader: false
    });
```

If the option is not set, the client will behave as it would normally.
