### PR TITLE
fix crash with circular objects

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -11,8 +11,13 @@ var events = require('events'),
     qs = require('querystring'),
     common = require('./common'),
     loggly = require('../loggly'),
-    Search = require('./search').Search;
+    Search = require('./search').Search,
+    stringifySafe = require('json-stringify-safe');
 
+function stringify(msg) {
+  var decycle = function () { return function () {};};
+  return stringifySafe(msg, null, null, decycle);
+}
 //
 // function createClient (options)
 //   Creates a new instance of a Loggly client.
@@ -88,6 +93,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
   var self = this,
       logOptions;
 
+
   //
   // Remark: Have some extra logic for detecting if we want to make a bulk
   // request to loggly
@@ -95,10 +101,10 @@ Loggly.prototype.log = function (msg, tags, callback) {
   var isBulk = Array.isArray(msg);
   function serialize (msg) {
     if (msg instanceof Object) {
-      return self.json ? JSON.stringify(msg) : common.serialize(msg);
+      return self.json ? stringify(msg) : common.serialize(msg);
     }
     else {
-      return self.json ? JSON.stringify({ message : msg }) : msg;
+      return self.json ? stringify({ message : msg }) : msg;
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": {
     "request": "2.27.x",
-    "timespan": "2.3.x"
+    "timespan": "2.3.x",
+    "json-stringify-safe": "5.0.x"
   },
   "devDependencies": {
     "vows": "0.7.x"
@@ -32,4 +33,3 @@
     "node": ">= 0.8.0"
   }
 }
-


### PR DESCRIPTION
If you pass a object with an circular reference, JSON.stringify throw an exception. Use json-stringify-safe to drop circular references from the log.
