### PR TITLE
loggly doesn't accept lowercase header name

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -143,7 +143,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
   if (tags) {
     //decide whether to add tags as http headers or add them to the URI.
     if (this.useTagHeader) {
-      logOptions.headers['x-loggly-tag'] = tags.join(',');
+      logOptions.headers['X-LOGGLY-TAG'] = tags.join(',');
     }
     else {
       logOptions.uri += "/tag/" + tags.join(",") + "/";


### PR DESCRIPTION
tags weren't being logged because of this
