### PR TITLE
Remove content-length header because it messes with some proxy configs

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -124,8 +124,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
       'host':           this.host,
       'accept':         '*/*',
       'user-agent':     this.userAgent,
-      'content-type':   this.json ? 'application/json' : 'text/plain',
-      'content-length': Buffer.byteLength(msg)
+      'content-type':   this.json ? 'application/json' : 'text/plain'
     }
   };
 


### PR DESCRIPTION
Submitting for your consideration, though I totally understand if it's rejected:

* I've been having trouble getting Loggly to log anything through a series of corporate proxies in our environment. The `request` module automatically picks up the `https_proxy` environment variable, and so all should be good.
* I haven't worked out exactly why, but when the content-length is set, one of the two proxies I'm going through hangs until the request eventually times out. In the interim, the callback doesn't fire and I suspect it sits there leaving the connection open because eventually (with enough `.log()` calls) it'll crash one of the proxies.
* Removing the content-length makes everything work :+1: though I can only guess as to why.

I can sort of guess why the content-length header it's there, but I'm just wondering how necessary it is and whether we can safely ditch it for compatibility reasons?
