### PR TITLE
Provide proxy support. Fixes #53

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -46,12 +46,12 @@ var Loggly = exports.Loggly = function (options) {
   }
 
   events.EventEmitter.call(this);
-
   this.subdomain    = options.subdomain;
   this.token        = options.token;
   this.host         = options.host || 'logs-01.loggly.com';
   this.json         = options.json || null;
   this.auth         = options.auth || null;
+  this.proxy        = options.proxy || null;
   this.userAgent    = 'node-loggly ' + loggly.version;
   this.useTagHeader = 'useTagHeader' in options ? options.useTagHeader : true;
 
@@ -117,6 +117,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
     uri:     isBulk ? this.urls.bulk : this.urls.log,
     method:  'POST',
     body:    msg,
+    proxy:   this.proxy,
     headers: {
       host:             this.host,
       accept:           '*/*',

--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -68,6 +68,7 @@ common.loggly = function () {
       headers,
       method,
       auth,
+      proxy,
       uri;
 
   //
@@ -88,6 +89,7 @@ common.loggly = function () {
       requestBody = args[0].body;
       auth        = args[0].auth;
       headers     = args[0].headers;
+      proxy       = args[0].proxy;
     }
   }
   else if (args.length === 2) {
@@ -111,7 +113,8 @@ common.loggly = function () {
   var requestOptions = {
     uri: uri,
     method: method,
-    headers: headers || {}
+    headers: headers || {},
+    proxy: proxy
   };
 
   if (auth) {


### PR DESCRIPTION
This will allow node-loggly to work behind a firewall through a web proxy.