### PR TITLE
Upgrade request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "loggly"
   ],
   "dependencies": {
-    "request": "2.67.x",
+    "request": "2.69.x",
     "timespan": "2.3.x",
     "json-stringify-safe": "5.0.x"
   },


### PR DESCRIPTION
Upgraded request to 2.69.x in order to address the issue discussed here: https://snyk.io/vuln/npm:request:20160119

Was not able to get tests running locally.