### PR TITLE
update request to 2.74.x to patch vulnerability in 2.67.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "loggly"
   ],
   "dependencies": {
-    "request": "2.67.x",
+    "request": "2.74.x",
     "timespan": "2.3.x",
     "json-stringify-safe": "5.0.x"
   },


### PR DESCRIPTION
The current version of `request` that this package depends on has a vulnerability that has been patched in a later version.  This upgrades to the latest.

More info: https://snyk.io/vuln/npm:request:20160119