### PR TITLE
Loosen semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "loggly"
   ],
   "dependencies": {
-    "request": "2.75.x",
-    "timespan": "2.3.x",
-    "json-stringify-safe": "5.0.x"
+    "request": "^2.75.0",
+    "timespan": "^2.3.0",
+    "json-stringify-safe": "^5.0.0"
   },
   "devDependencies": {
     "common-style": "^3.1.0",


### PR DESCRIPTION
request 2.75.0 depends, via a few different dependency chains, on `hoek`, which is flagged as a moderate security risk by `npm audit`. Widening the semver range for request allows the latest version of hoek - which patches the security flaw - to be picked up. I've also widened the other semver ranges in your dependencies to improve the library's ability to pick up security patches automatically.