### PR TITLE
Update `request` for secure

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "loggly"
   ],
   "dependencies": {
-    "request": "2.75.x",
+    "request": "2.87.x",
     "timespan": "2.3.x",
     "json-stringify-safe": "5.0.x"
   },


### PR DESCRIPTION
The `hoek` package has a potential security vulnerability. And, `request` package uses it. Therefore, I think that the `request` package should be updated.